### PR TITLE
Allow failure of Firefox on Travis; use Firefox on SauceLabs instead 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,14 @@ matrix:
       script:
         - ./vendor/bin/steward run production $BROWSER -vvv --server-url=http://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@ondemand.saucelabs.com  --capability="platform:Windows 10" --capability="version:'14.14393'"
       after_script: ~
+    - php: 7
+      env: BROWSER=firefox SAUCELABS=1 # run tests in Firefox on SauceLabs cloud
+      install:
+        - composer install --no-interaction
+      before_script: ~
+      script:
+        - ./vendor/bin/steward run production $BROWSER -vvv --server-url=http://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@ondemand.saucelabs.com  --capability="platform:Windows 10" --capability="version:'52.0'"
+      after_script: ~
   allow_failures:
     - env: BROWSER=firefox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
       script:
         - ./vendor/bin/steward run production $BROWSER -vvv --server-url=http://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@ondemand.saucelabs.com  --capability="platform:Windows 10" --capability="version:'14.14393'"
       after_script: ~
+  allow_failures:
+    - env: BROWSER=firefox
 
 before_install:
   - cd selenium-tests/


### PR DESCRIPTION
This should be just temporary, until https://github.com/mozilla/geckodriver/issues/285 is fixed (Firefox 54?). 