### PR TITLE
Update to latest Selenium & geckodriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ addons:
 
 env:
   global:
-    - SELENIUM_SERVER_VERSION="3.3.1"
-    - GECKODRIVER_VERSION="0.15.0"
+    - SELENIUM_SERVER_VERSION="3.4.0"
+    - GECKODRIVER_VERSION="0.16.0"
   matrix:
     - BROWSER=phantomjs
     - BROWSER=firefox


### PR DESCRIPTION
Should fix current error, however introduces a new one :). https://github.com/mozilla/geckodriver/issues/670

So Firefox builds are still marked as allowed failure on Travis...